### PR TITLE
feat(tokenizer): add <|endoftext|> and <|unk|> special tokens

### DIFF
--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -22,11 +22,14 @@ def test_punctuation_handling():
     assert decoded == text
 
 
-def test_unknown_token_error():
+def test_unknown_token_mapping():
+    # Unknown tokens should map to UNKNOWN_TOKEN_INDEX
     tokenizer = Tokenizer(vocabulary={"a": 0})
-    with pytest.raises(ValueError) as exc:
-        tokenizer.encode("b")
-    assert "Unknown token" in str(exc.value)
+    encoded = tokenizer.encode("b")
+    assert encoded == [tokenizer.UNKNOWN_TOKEN_INDEX]
+    # Decoding unknown token index yields UNKNOWN_TOKEN
+    decoded = tokenizer.decode(encoded)
+    assert decoded == tokenizer.UNKNOWN_TOKEN
 
 
 def test_custom_vocab_initialization():
@@ -37,3 +40,14 @@ def test_custom_vocab_initialization():
     assert encoded == [1, 2]
     decoded = tokenizer.decode([2, 1])
     assert decoded == "b a"
+
+
+def test_special_tokens_in_vocab():
+    # Special tokens should be in vocabulary
+    tokenizer = Tokenizer(dataset="a")
+    vocab = tokenizer.get_vocabulary()
+    assert Tokenizer.END_OF_TEXT_TOKEN in vocab
+    assert Tokenizer.UNKNOWN_TOKEN in vocab
+    # Indices should match tokenizer attributes
+    assert tokenizer.END_OF_TEXT_INDEX == vocab[Tokenizer.END_OF_TEXT_TOKEN]
+    assert tokenizer.UNKNOWN_TOKEN_INDEX == vocab[Tokenizer.UNKNOWN_TOKEN]

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -31,6 +31,18 @@ def test_unknown_token_mapping():
     decoded = tokenizer.decode(encoded)
     assert decoded == tokenizer.UNKNOWN_TOKEN
 
+    # Test encoding and decoding of the unknown token itself
+    encoded_unk = tokenizer.encode(tokenizer.UNKNOWN_TOKEN)
+    assert encoded_unk == [tokenizer.UNKNOWN_TOKEN_INDEX]
+    decoded_unk = tokenizer.decode(encoded_unk)
+    assert decoded_unk == tokenizer.UNKNOWN_TOKEN
+
+    # Test encoding and decoding of the end-of-text token
+    encoded_eot = tokenizer.encode(tokenizer.END_OF_TEXT_TOKEN)
+    assert encoded_eot == [tokenizer.END_OF_TEXT_INDEX]
+    decoded_eot = tokenizer.decode(encoded_eot)
+    assert decoded_eot == tokenizer.END_OF_TEXT_TOKEN
+
 
 def test_custom_vocab_initialization():
     vocab = {"a": 1, "b": 2}


### PR DESCRIPTION
This PR enhances the Tokenizer to better support sequence boundaries and unknown inputs by:

1. Introducing special tokens
   * END_OF_TEXT_TOKEN (<|endoftext|>)
   * UNKNOWN_TOKEN (<|unk|>)
1. Automatic vocabulary integration
   * Both tokens are appended to the vocabulary with unique, collision‑free indices.
   * Exposed via END_OF_TEXT_INDEX and UNKNOWN_TOKEN_INDEX attributes.
1. Robust encoding of unseen tokens
   * Unknown tokens are now mapped to UNKNOWN_TOKEN_INDEX instead of raising an error.
   * Enables continued encoding even when encountering out‑of‑vocabulary words.
1. Test coverage updates
   * Replaces the old test_unknown_token_error with test_unknown_token_mapping to verify mapping behavior.
   * Adds test_special_tokens_in_vocab to ensure the new tokens exist in every vocabulary and their indices match the tokenizer’s attributes.

All existing and new tests pass, ensuring backward compatibility for basic encoding/decoding and covering the new behaviors.

## Summary by Sourcery

Add special `<|endoftext|>` and `<|unk|>` tokens to the tokenizer and handle unknown tokens gracefully.

New Features:
- Introduce `END_OF_TEXT_TOKEN` (`<|endoftext|>`) and `UNKNOWN_TOKEN` (`<|unk|>`).
- Automatically append special tokens to the vocabulary upon initialization.
- Encode unknown tokens as `UNKNOWN_TOKEN_INDEX` instead of raising an error.

Tests:
- Verify that unknown tokens are mapped to the `UNKNOWN_TOKEN_INDEX`.
- Ensure special tokens are correctly added to the vocabulary and indexed.